### PR TITLE
Fixing twitch help.

### DIFF
--- a/main.go
+++ b/main.go
@@ -179,7 +179,7 @@ func generateTwitchHelp(soundOptions []string) string {
 	for _, soundCategory := range getXRandomItems(soundOptions, 3) {
 		// Don't tell people about local-only sound categorites (marked with a _ at the end of the dir name)
 		if !strings.HasSuffix(soundCategory, "_") {
-			helpMessage = helpMessage + "!" + soundCategory[2:] + "\\n"
+			helpMessage = helpMessage + "!" + soundCategory + "\\n"
 		}
 	}
 


### PR DESCRIPTION
Since we're already parsing the file name to remove prefix when we generate the list of options we don't need to do it again.

#hacktoberfest